### PR TITLE
Lock doctrine/cache version to maintain PHP requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "doctrine/cache": "^1.6",
+    "doctrine/cache": "1.6.2",
     "psr/cache": "^1.0",
     "psr/simple-cache": "^1.0"
   },


### PR DESCRIPTION
Keeping PHP requirements at 5.x

Doctrine Cache 1.7.x and higher require PHP 7