### PR TITLE
Upgrade to psr/cache v3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-  - 7.3
-  - 7.4
   - 8.0
 sudo: false
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: php
-php:
-  - 8.0
+matrix:
+  include:
+    - php: 8.0
+    - php: 8.0
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 sudo: false
 install:
-  - composer install
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     }
   },
   "provide": {
-    "psr/cache-implementation": "3.0",
+    "psr/cache-implementation": "2.0|3.0",
     "psr/simple-cache-implementation": "1.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": ">=8.0",
     "doctrine/cache": "^1.10",
-    "psr/cache": "^3.0",
+    "psr/cache": "^2.0 || ^3.0",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
-    "doctrine/cache": "^1.6",
-    "psr/cache": "^1.0",
+    "php": ">=8.0",
+    "doctrine/cache": "^1.10",
+    "psr/cache": "^3.0",
     "psr/simple-cache": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0"
+    "phpunit/phpunit": "^9.0"
   },
   "autoload": {
     "psr-4": {
@@ -31,7 +31,7 @@
     }
   },
   "provide": {
-    "psr/cache-implementation": "1.0",
+    "psr/cache-implementation": "3.0",
     "psr/simple-cache-implementation": "1.0"
   }
 }

--- a/src/Item.php
+++ b/src/Item.php
@@ -34,24 +34,24 @@ class Item implements CacheItemInterface
     /**
      * @var string
      */
-    protected $key;
+    protected string $key;
 
     /**
      * @var mixed
      */
-    protected $value;
+    protected mixed $value;
 
     /**
      * @var boolean
      */
-    protected $isHit;
+    protected bool $isHit;
 
     /**
      * @var integer
      */
-    protected $ttl;
+    protected int $ttl;
 
-    public function __construct($key, $value, $isHit, $ttl = 0)
+    public function __construct(string $key, mixed $value, bool $isHit, int $ttl = 0)
     {
         $this->key   = $key;
         $this->value = $value;
@@ -59,22 +59,22 @@ class Item implements CacheItemInterface
         $this->ttl   = $ttl;
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
 
-    public function get()
+    public function get(): mixed
     {
         return $this->value;
     }
 
-    public function isHit()
+    public function isHit(): bool
     {
         return $this->isHit;
     }
 
-    public function set($value)
+    public function set(mixed $value): static
     {
         $this->value = $value;
 
@@ -84,7 +84,7 @@ class Item implements CacheItemInterface
     /**
      * @inheritdoc
      */
-    public function expiresAt($expiration)
+    public function expiresAt(int|\DateTimeInterface|null $expiration): static
     {
         if (is_int($expiration)) {
             $this->ttl = $expiration - time();
@@ -99,7 +99,7 @@ class Item implements CacheItemInterface
         return $this;
     }
 
-    public function expiresAfter($time)
+    public function expiresAfter(int|\DateInterval|null $time): static
     {
         if (is_int($time)) {
             $this->ttl = $time;
@@ -116,7 +116,7 @@ class Item implements CacheItemInterface
         return $this;
     }
 
-    public function getTtl()
+    public function getTtl(): int
     {
         return $this->ttl;
     }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -36,12 +36,12 @@ class Pool implements CacheItemPoolInterface
     /**
      * @var \Doctrine\Common\Cache\CacheProvider
      */
-    protected $handler;
+    protected CacheProvider $handler;
 
     /**
      * @var array
      */
-    protected $items;
+    protected array $items;
 
     public function __construct(CacheProvider $handler)
     {
@@ -54,7 +54,7 @@ class Pool implements CacheItemPoolInterface
         $this->handler = $handler;
     }
 
-    public function getItem($key)
+    public function getItem(string $key): CacheItemInterface
     {
         $data = $this->handler->fetch($key);
 
@@ -65,7 +65,7 @@ class Pool implements CacheItemPoolInterface
         }
     }
 
-    public function getItems(array $keys = array())
+    public function getItems(array $keys = []): iterable
     {
         $result = [];
         $data   = $this->handler->fetchMultiple($keys);
@@ -81,22 +81,22 @@ class Pool implements CacheItemPoolInterface
         return $result;
     }
 
-    public function hasItem($key)
+    public function hasItem(string $key): bool
     {
         return $this->handler->contains($key);
     }
 
-    public function clear()
+    public function clear(): bool
     {
         return $this->handler->flushAll();
     }
 
-    public function deleteItem($key)
+    public function deleteItem(string $key): bool
     {
         return $this->handler->delete($key);
     }
 
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
         $result = true;
         foreach ($keys as $key) {
@@ -108,19 +108,19 @@ class Pool implements CacheItemPoolInterface
         return $result;
     }
 
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
         return $this->handler->save($item->getKey(), $item->get(), $item->getTtl());
     }
 
-    public function saveDeferred(CacheItemInterface $item)
+    public function saveDeferred(CacheItemInterface $item): bool
     {
         $this->items[] = $item;
 
         return true;
     }
 
-    public function commit()
+    public function commit(): bool
     {
         $result = true;
         foreach ($this->items as $item) {

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -22,6 +22,7 @@ namespace PSX\Cache\Tests;
 
 use DateInterval;
 use DateTime;
+use TypeError;
 use PHPUnit\Framework\TestCase;
 use PSX\Cache\Item;
 
@@ -69,15 +70,13 @@ class ItemTest extends TestCase
         $this->assertEquals(0, $item->getTtl());
     }
 
-    /**
-     * @expectedException \PSX\Cache\Exception
-     */
     public function testExpiresAtInvalidType()
     {
         $item = new Item('key', null, false);
 
         $this->assertEquals(0, $item->getTtl());
 
+        $this->expectException(TypeError::class);
         $item->expiresAt('foo');
     }
 
@@ -116,15 +115,13 @@ class ItemTest extends TestCase
         $this->assertEquals(0, $item->getTtl());
     }
 
-    /**
-     * @expectedException \PSX\Cache\Exception
-     */
     public function testExpiresAfterInvalidType()
     {
         $item = new Item('key', null, false);
 
         $this->assertEquals(0, $item->getTtl());
 
+        $this->expectException(TypeError::class);
         $item->expiresAfter('foo');
     }
 }


### PR DESCRIPTION
There is a new `psr/cache` version 3.0 which requires PHP 8.0 and supports more type hints.